### PR TITLE
Redundant code in handleEvents

### DIFF
--- a/programs/Events/Main.hs
+++ b/programs/Events/Main.hs
@@ -89,8 +89,6 @@ handleEvent s (VtyEvent e) =
         (EvKey (KChar 'd') [MCtrl])            -> return $ moveCurrentLayerDown s
         (EvKey (KChar 'v') [MCtrl])            -> return $ toggleCurrentLayer s
         (EvKey (KChar 'C') [])                 -> return $ recenterCanvas s
-        (EvKey (KChar 'f') [])                 -> return $ beginFgPaletteSelect s
-        (EvKey (KChar 'b') [])                 -> return $ beginBgPaletteSelect s
         (EvKey (KChar '>') [])                 -> return $ increaseToolSize s
         (EvKey (KChar '<') [])                 -> return $ decreaseToolSize s
         (EvKey KEsc []) | isJust (s^.dragging) -> return $ cancelDragging s


### PR DESCRIPTION
Firstly, thanks to this awesome program!
I'm so happy to find this and using it.

While reading codes, I found those lines below.
I think they are redundant, because `handleCommonEvent` is always executed before `Events.Main.handleEvent`.
If they are so, I want to make PR to delete first one (`Events/Main.hs#L92-93`)
Or are there any reason for this?


https://github.com/jtdaugherty/tart/blob/2aee945eabd0e2461f20d8e10147e9f35a915122/programs/Events/Main.hs#L92-L93

https://github.com/jtdaugherty/tart/blob/2aee945eabd0e2461f20d8e10147e9f35a915122/programs/Events/Common.hs#L17-L24